### PR TITLE
Misc: Remove node resovle

### DIFF
--- a/packages/proof-service/src/api/client.ts
+++ b/packages/proof-service/src/api/client.ts
@@ -2,7 +2,7 @@ import * as pkg from '@apollo/client';
 const { ApolloClient, InMemoryCache, HttpLink } = pkg;
 
 const httpLink = new HttpLink({
-  uri: 'http://localhost:5000/graphql',
+  uri: 'http://localhost:4000/graphql',
   fetch,
 });
 

--- a/packages/proof-service/src/api/client.ts
+++ b/packages/proof-service/src/api/client.ts
@@ -2,7 +2,7 @@ import * as pkg from '@apollo/client';
 const { ApolloClient, InMemoryCache, HttpLink } = pkg;
 
 const httpLink = new HttpLink({
-  uri: 'http://localhost:4000/graphql',
+  uri: 'http://localhost:5000/graphql',
   fetch,
 });
 

--- a/packages/smart-contract/package.json
+++ b/packages/smart-contract/package.json
@@ -31,7 +31,6 @@
     "@babel/preset-typescript": "^7.16.0",
     "@rollup/plugin-alias": "^5.1.1",
     "@rollup/plugin-commonjs": "^28.0.0",
-    "@rollup/plugin-node-resolve": "^15.3.0",
     "@rollup/plugin-typescript": "^12.1.0",
     "@types/jest": "^29.5.13",
     "@typescript-eslint/eslint-plugin": "^5.5.0",

--- a/packages/smart-contract/rollup.config.js
+++ b/packages/smart-contract/rollup.config.js
@@ -1,7 +1,6 @@
 import typescript from '@rollup/plugin-typescript';
 import alias from '@rollup/plugin-alias';
 import commonjs from '@rollup/plugin-commonjs';
-import nodeResolve from '@rollup/plugin-node-resolve';
 
 export default {
   input: 'src/index.ts',
@@ -22,7 +21,6 @@ export default {
         { find: '@types', replacement: 'src/types' },
       ],
     }),
-    nodeResolve(),
     typescript({ sourceMap: true, tsconfig: 'tsconfig.json' }),
   ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9565,6 +9565,7 @@ string-template@~0.2.1:
   integrity sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9647,6 +9648,7 @@ stringify-entities@^4.0.0:
     character-entities-legacy "^3.0.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  name strip-ansi-cjs
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10488,6 +10490,7 @@ wordwrap@^1.0.0:
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Type

- [ ] Feature
- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Other

## Description
Remove this node resolve cause build error with eval in smart contract package
```
undefined:1
require('crypto')
^

ReferenceError: require is not defined in ES module scope, you can use import instead
This file is being treated as an ES module because it has a '.js' file extension and '/Users/Desktop/zkDatabase/packages/smart-contract/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
    at eval (eval at nodeWrap
```

Brief description of the changes made.
