### PR TITLE
fix: update mongo keyfile path in docker-compose and serverless dockerfile

### DIFF
--- a/general/database/docker-compose.yml
+++ b/general/database/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - MONGO_INITDB_ROOT_USERNAME=admin
       - MONGO_INITDB_ROOT_PASSWORD=password
     volumes:
-      - ./data/mongo-keyfile/rs_keyfile:/etc/mongodb/pki/keyfile
+      - ./mongo-keyfile/rs_keyfile:/etc/mongodb/pki/keyfile
       - ./data/mongo-data:/data/db
       - ./data/mongo-config:/data/configdb
     networks:

--- a/packages/serverless/Dockerfile
+++ b/packages/serverless/Dockerfile
@@ -39,6 +39,7 @@ RUN addgroup -S appuser && adduser -S -G appuser -h /usr/src/app appuser
 WORKDIR /usr/src/app
 
 # Copy the application code and node_modules from the builder stage
+COPY --from=builder --chown=appuser:appuser /usr/src/app/packages/smart-contract /usr/src/app/packages/smart-contract
 COPY --from=builder --chown=appuser:appuser /usr/src/app/packages/storage /usr/src/app/packages/storage
 COPY --from=builder --chown=appuser:appuser /usr/src/app/packages/serverless /usr/src/app/packages/serverless
 COPY --from=builder --chown=appuser:appuser /usr/src/app/node_modules /usr/src/app/node_modules


### PR DESCRIPTION
fix: update mongo keyfile path in docker-compose and serverless dockerfile
## Type

- [ ] Feature
- [ ] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Other

## Description

fix: update mongo keyfile path in docker-compose and serverless dockerfile