### PR TITLE
Refactor: fix document endpoint types and database related logic

### DIFF
--- a/packages/serverless/src/domain/use-case/document.ts
+++ b/packages/serverless/src/domain/use-case/document.ts
@@ -1,3 +1,6 @@
+// TODO: need end to end testing for every function in this file
+// TODO: debug types to annotate the actual correct types
+
 import {
   EDatabaseProofStatus,
   TDocumentField,
@@ -16,7 +19,7 @@ import {
   withTransaction,
   zkDatabaseConstants,
 } from '@zkdb/storage';
-import { ClientSession, WithId } from 'mongodb';
+import { ClientSession } from 'mongodb';
 import {
   PERMISSION_DEFAULT_VALUE,
   ZKDATABASE_GROUP_SYSTEM,

--- a/packages/serverless/src/domain/utils/document.ts
+++ b/packages/serverless/src/domain/utils/document.ts
@@ -2,6 +2,27 @@ export interface FilterCriteria {
   [key: string]: any;
 }
 
+/** Parse a arbitrary query to a query that queries either the `docId` or the
+ * `document` fields.
+ *
+ * For example, the input:
+ * ```
+ * {
+ *   docId: '123',
+ *   name: 'John',
+ *   age: 30,
+ *   address: undefined,
+ * }
+ * ```
+ *
+ * will be parsed to:
+ * ```
+ * {
+ *   docId: '123',
+ *   'document.name.value': 'John',
+ *   'document.age.value': 30,
+ * }
+ * */
 export function parseQuery(input: FilterCriteria): FilterCriteria {
   const query: FilterCriteria = {};
 
@@ -12,7 +33,7 @@ export function parseQuery(input: FilterCriteria): FilterCriteria {
       if (key === 'docId') {
         query[key] = String(value);
       } else {
-        query[`${key}.value`] = value;
+        query[`document.${key}.value`] = value;
       }
     }
   });


### PR DESCRIPTION
- User data fields are now stored under the `document` key. This avoid key collision with the document metadata.
- Updated the query pipeline to reflect the above change
- User data field values are now stored as string consistently no matter which application types they are

## Type

- [ ] Feature
- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Other

## Description

Brief description of the changes made.
