### PR TITLE
Fix document exclusion queue get dequeue immediately after enqueued

### DIFF
--- a/packages/mina-service/src/service/document-worker.ts
+++ b/packages/mina-service/src/service/document-worker.ts
@@ -82,8 +82,8 @@ export class DocumentWorker {
         );
 
         if (task.sequenceNumber <= trackingSequenceNumber) {
-          exclusionQueue.push(task.databaseName);
           exclusionQueue.shift();
+          exclusionQueue.push(task.databaseName);
           logger.debug(
             `Task sequence number of task ${task._id} is less than or equal \
 to the current tracking sequence number. This is expected as the workers  \
@@ -101,8 +101,8 @@ ${task.sequenceNumber}, tracking sequence number: ${trackingSequenceNumber}`
           BigInt(task.sequenceNumber) !==
           BigInt(trackingSequenceNumber) + 1n
         ) {
-          exclusionQueue.push(task.databaseName);
           exclusionQueue.shift();
+          exclusionQueue.push(task.databaseName);
           return true;
         }
 


### PR DESCRIPTION
This commit fixes the flaw in the logic of the document exclusion queue. The queue was dequeuing the database immediately after enqueuing it. The fix is to dequeue and then enqueue the database so that the next iteration the database will be excluded.

## Type

- [ ] Feature
- [ ] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Other

## Description

Brief description of the changes made.
