### PR TITLE
Disable CSP upgrade-insecure-requests

### DIFF
--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -104,6 +104,10 @@ const EXPRESS_SESSION_EXPIRE_TIME = 86400;
           imgSrc: ["'self'", '*.cdn.apollographql.com'],
           // Allow loading Graphql Playground manifest
           manifestSrc: ["'self'", '*.cdn.apollographql.com'],
+          // Don't automatically upgrade HTTP requests to HTTPS so that Graphql
+          // Studio can work over HTTP to fetch schemas, etc. on test
+          // environments
+          upgradeInsecureRequests: null,
         },
       },
       // set the “X-Frame-Options” header to prevent clickjacking attacks


### PR DESCRIPTION
This commit disables the CSP upgrade-insecure-requests directive so that the client can make HTTP requests (e.g. fetch schema) when the Apollo Studio is served over HTTP, instead of being upgraded to HTTPS which does not exists for local environment.

## Type

- [ ] Feature
- [ ] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Other

## Description

Brief description of the changes made.
