### PR TITLE
fix: cover case where prover status is queued when processing

### DIFF
--- a/packages/serverless/src/apollo/app/proof.ts
+++ b/packages/serverless/src/apollo/app/proof.ts
@@ -129,6 +129,15 @@ const proverStatus = publicWrapper<TProverStatusRequest, TProverStatusResponse>(
         EQueueType.RollupOffChainQueue,
         session
       );
+      const rollupOffchainStatus =
+        await imRollupOffchainQueue.databaseLatestStatus(databaseName, session);
+
+      if (
+        rollupOffchainStatus === EQueueTaskStatus.Queued &&
+        documentQueueStatus === EQueueTaskStatus.Processing
+      ) {
+        return EQueueTaskStatus.Processing;
+      }
 
       // NOTE: This assumes that the rollup offchain queue is always slower
       // than the document queue, thus we can use the latest status of the
@@ -136,9 +145,9 @@ const proverStatus = publicWrapper<TProverStatusRequest, TProverStatusResponse>(
       //
       // A correct implementation needs to account for the possibility that the
       // rollup offchain queue is faster than the document queue, in which case
-      // we have 5 * 5 = 25 possible states to consider, which is not worth it
+      // we have 5 * 4 = 20 possible states to consider, which is not worth it
       // for now.
-      return imRollupOffchainQueue.databaseLatestStatus(databaseName, session);
+      return rollupOffchainStatus;
     })
 );
 

--- a/packages/serverless/src/domain/use-case/document-schema.ts
+++ b/packages/serverless/src/domain/use-case/document-schema.ts
@@ -11,9 +11,6 @@ import Joi from 'joi';
 
 const schemaVerification: Map<TProvableTypeString, Joi.Schema> = new Map();
 
-// NOTE: not used but keeping here for reference
-// TODO: remove when synchronized with the upper level validators
-// Every data type will be treaded as string when store/transfer
 if (schemaVerification.size === 0) {
   const base58String = Joi.string()
     .max(256)


### PR DESCRIPTION
Return "Processing" status early when rollup offchain task is queued and document queue is processing. Update comment to reflect 20 possible states instead of 25.

## Type

- [ ] Feature
- [ ] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Other

## Description

Brief description of the changes made.
