### PR TITLE
fix: correct EIndexType enum comment mapping values

### DIFF
--- a/packages/common/src/types/collection.ts
+++ b/packages/common/src/types/collection.ts
@@ -8,8 +8,8 @@ import { TCollectionMetadata } from './metadata.js';
 /**
  * Sorting type
  * @enum
- * @property {string} Asc - Ascending -1
- * @property {string} Desc - Descending 1
+ * @property {string} Asc - Ascending (maps to MongoDB value: 1)
+ * @property {string} Desc - Descending (maps to MongoDB value: -1)
  */
 export enum EIndexType {
   Asc = 'Asc',


### PR DESCRIPTION
Fixes incorrect MongoDB value mapping in EIndexType JSDoc comments.
The comments previously stated Asc maps to -1 and Desc to 1, but
the actual implementation maps Asc to 1 and Desc to -1, which
matches MongoDB's standard index direction values.